### PR TITLE
Fixes an issue where error codes 0000 and 0001 weren't being evaluated in the access codes page

### DIFF
--- a/src/app/pages/access-code/access-code.page.ts
+++ b/src/app/pages/access-code/access-code.page.ts
@@ -128,6 +128,14 @@ export class AccessCodePage implements OnInit {
 
       return new Promise(resolve => {
         loading.dismiss();
+        this.avclientService.requestAccessCode(this.data).catch(res => {
+          console.log("res", res);
+          if (res == 'Error: voter record not found') {
+            this.route.navigate(['/voter_record_notfound00000_error']);
+          } else if (res == 'Error: network code') {
+            this.route.navigate(['/check_network_request00001_error']);
+          }
+        });
         this.avclientService.validateAccessCode(this.data).catch(res => {
           console.log("res", res);
         });

--- a/src/app/pages/request-access-code/request-access-code.page.ts
+++ b/src/app/pages/request-access-code/request-access-code.page.ts
@@ -36,14 +36,6 @@ Continuebtn() {
         t: new Date().getTime()
       }]);
     }
-    this.avclientService.requestAccessCode(opaqueVoterId).catch(res => {
-      console.log("res", res);
-      if (res == 'Error: voter record not found') {
-        this.route.navigate(['/voter_record_notfound00000_error']);
-      } else if (res == 'Error: network code') {
-        this.route.navigate(['/check_network_request00001_error']);
-      }
-    });
   }
 }
 backbtn() {


### PR DESCRIPTION
Fixes an issue where error codes 0000 and 0001 weren't being evaluated in the access codes page. This is because they're handled in the `requestAccessCode` function, which is called in the "request access code" page. This is the page _before_ the access code page - where all you're doing is agreeing to get the code.

To fix the bug, this PR moves the function call to the "access code" page. This is the page where you type in the code and press "Next." Moving the code here ensures that all error codes are evaluated at the appropriate time.