### PR TITLE
THAJ-127 Choose a Return styling

### DIFF
--- a/src/app/pages/ballot-complete/ballot-complete.page.html
+++ b/src/app/pages/ballot-complete/ballot-complete.page.html
@@ -5,8 +5,7 @@
 </ion-header>
 <ion-content>
   <div class="cen-div-text" (click)="physicalret(); ballotReturnChoice('physical')">
-    <h3>{{results.physical_return}} <br /></h3>
-    <h4>{{results.requires_printer}}</h4>
+    <h3>{{results.physical_return}}</h3>
 
     <ion-icon name="mail-outline"></ion-icon>
   </div>

--- a/src/assets/inputFile/input.json
+++ b/src/assets/inputFile/input.json
@@ -23,8 +23,7 @@
     "ballot_comp": {
       "thank_you": "Thank you",
       "choose_a_return": "Choose A Return",
-      "physical_return": "Physical Return",
-      "requires_printer": "Requires a Printer",
+      "physical_return": "Physical Return. This option requires a printer.",
       "online_ballot_return": "Digital Return"
     },
 


### PR DESCRIPTION
Choose a Return styling

Description

Visually, the current “Choose a Return” screen is good …. for a sighted person.  

For a blind person, it is hard to use because the envelope and monitor images are labeled just “Image” when a person is using Apple’s Voiceover or Android’s TalkBack accessibility feature.  

Change the labeling so when a person hovers over the first area, Voiceover reads the entire area as “Physical Return. This option requires a printer.” and Voiceover reads the entire second area as “Digital Return.” There are a couple of ways to solve for that. below are some links and examples.

Here is an best practices article, 